### PR TITLE
raix:push-update -> server generates record id rather than client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /versions.json
+.idea
 .build*

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Stores a token associated with an application and optionally, a userId.
 * `appName` - String - the name of the application to associate the token with
 * `userId` - String (optional) - the user id so associate with the token and application. If none is included no user will be associated. Use `raix:push-setuser` to later associate a userId with a token.
 
-** Returns **:
+**Returns**:
 
 *recordId* - The id of the stored document associating appName, token, and optionally user in an object of the form:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 raix:push Push notifications
 =========
 
-Push notifications for cordova (ios, android) browser (Chrome, Safari, Firefox) - One unified api on client and server.
+> Push notifications for cordova (ios, android) browser (Chrome, Safari, Firefox) - One unified api on client and server.
 
 Status:
 * [x] APN iOS
@@ -89,6 +89,51 @@ When a client calls send on Push, the Push's allow and deny callbacks are called
         }
     });
 ```
+
+## Meteor Methods
+
+### raix:push-update
+
+Stores a token associated with an application and optionally, a userId.
+
+**Parameters**:
+
+*options* - An object containing the necessary data to store a token. Fields:
+* `id` - String (optional) - a record id for the stored FIXME
+* `token` - Object - `{ apn: 'TOKEN' }` or `{ gcm: 'TOKEN' }`
+* `appName` - String - the name of the application to associate the token with
+* `userId` - String (optional) - the user id so associate with the token and application. If none is included no user will be associated. Use `raix:push-setuser` to later associate a userId with a token.
+
+** Returns **:
+
+*recordId* - The id of the stored document associating appName, token, and optionally user in an object of the form:
+
+```
+{
+  result: 'recordId'
+}
+```
+
+### raix:push-setuser
+
+Associates the current users ID with an Application/Token record based on the given id.
+
+**Parameters**:
+
+*id* - String - The ID of the Application/Token record
+
+### raix:push-metadata
+
+Adds metadata to a particular Application/Token record.
+
+**Parameters**
+
+*data* - Object containing the following fields:
+* `id` - String - the ID of the Application/Token record to update
+* `metadata` - Object - The metadata object to add to the Application/Token document
+
+## More Info
+
 
 For more internal or advanced features read [ADVANCED.md](docs/ADVANCED.md)
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Stores a token associated with an application and optionally, a userId.
 **Parameters**:
 
 *options* - An object containing the necessary data to store a token. Fields:
-* `id` - String (optional) - a record id for the stored FIXME
+* `id` - String (optional) - a record id for the Application/Token document to update. If this does not exist, will return 404.
 * `token` - Object - `{ apn: 'TOKEN' }` or `{ gcm: 'TOKEN' }`
 * `appName` - String - the name of the application to associate the token with
 * `userId` - String (optional) - the user id so associate with the token and application. If none is included no user will be associated. Use `raix:push-setuser` to later associate a userId with a token.

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -118,6 +118,6 @@ Meteor.methods({
     console.warn('Not implemented yet');
 
     // return notificationId;
-  },
+  }
 });
 

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -18,8 +18,7 @@ Meteor.methods({
       id: String,
       token: _matchToken,
       appName: String,
-      userId: Match.OneOf(String, null),
-      metadata: Object
+      userId: Match.OneOf(String, null)
     });
 
     // The if user id is set then user id should match on client and connection

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -15,25 +15,27 @@ Meteor.methods({
     if (Push.debug) console.log('Push: Got push token from app:', options);
 
     check(options, {
+      id: Match.Optional(String),
       token: _matchToken,
       appName: String,
       userId: Match.OneOf(String, null)
     });
 
     // The if user id is set then user id should match on client and connection
-    if (options.userId && options.userId !== this.userId)
+    if (options.userId && options.userId !== this.userId) {
       throw new Meteor.Error(403, 'Forbidden access');
+    }
 
-    var app;
+    var doc;
 
     // lookup app by id if one was included
     if (options.id) {
-      app = Push.appCollection.findOne({ _id: options.id });
+      doc = Push.appCollection.findOne({ _id: options.id });
     }
 
     // No id was sent by the client - we check the database to see if
     // we can find a match for the app via token and appName
-    if (!app) app = Push.appCollection.findOne({
+    if (!doc) doc = Push.appCollection.findOne({
       $and: [
         { token: options.token },
         { appName: options.appName }
@@ -41,10 +43,9 @@ Meteor.methods({
     });
 
     // if we could not find the id or token then create it
-    if (!app) {
-
+    if (!doc) {
       // Rig default doc
-      var doc = {
+      doc = {
         token: options.token,
         appName: options.appName,
         userId: options.userId,
@@ -53,18 +54,10 @@ Meteor.methods({
       };
 
       // Get the id from insert
-      var id = Push.appCollection._collection.insert(doc);
-
-      // This should be true
-      if (id == doc._id) {
-        app = doc;
-
-        if (Push.debug) console.log('Push: Inserted token in app collection');
-      }
-
+      doc._id = Push.appCollection.insert(doc);
     } else {
       // We found the app so update the updatedAt and set the token
-      Push.appCollection.update({ _id: app._id }, {
+      Push.appCollection.update({ _id: doc._id }, {
         $set: {
           updatedAt: new Date(),
           token: options.token
@@ -72,14 +65,15 @@ Meteor.methods({
       });
     }
 
-    if (app && Push.debug) console.log('Push: Using', app);
-
-    if (!app) {
-      throw new Meteor.Error(500, 'setPushToken could not create record');
+    if (doc && Push.debug) {
+      console.log('Push: updated', doc);
     }
 
+    if (!doc) {
+      throw new Meteor.Error(500, 'setPushToken could not create record');
+    }
     // Return the id we want to use
-    return app._id;
+    return doc._id;
   },
   'raix:push-setuser': function(id) {
     check(id, String);

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -15,7 +15,6 @@ Meteor.methods({
     if (Push.debug) console.log('Push: Got push token from app:', options);
 
     check(options, {
-      id: String,
       token: _matchToken,
       appName: String,
       userId: Match.OneOf(String, null)
@@ -25,11 +24,15 @@ Meteor.methods({
     if (options.userId && options.userId !== this.userId)
       throw new Meteor.Error(403, 'Forbidden access');
 
-    // if we could not find the token then lookup id
-    var app = Push.appCollection.findOne({ _id: options.id });
+    var app;
 
-    // The id is newly created by the client - we check the database to see if
-    // we can find an older match for the app via token
+    // lookup app by id if one was included
+    if (options.id) {
+      app = Push.appCollection.findOne({ _id: options.id });
+    }
+
+    // No id was sent by the client - we check the database to see if
+    // we can find a match for the app via token and appName
     if (!app) app = Push.appCollection.findOne({
       $and: [
         { token: options.token },
@@ -42,7 +45,6 @@ Meteor.methods({
 
       // Rig default doc
       var doc = {
-        _id: options.id,
         token: options.token,
         appName: options.appName,
         userId: options.userId,

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -31,6 +31,10 @@ Meteor.methods({
     // lookup app by id if one was included
     if (options.id) {
       doc = Push.appCollection.findOne({ _id: options.id });
+
+      if (!doc) {
+        throw new Meteor.Error(404, 'raix:push-update could not find the record specified by ID');
+      }
     }
 
     // No id was sent by the client - we check the database to see if

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'workpop:push',
-  version: '2.5.4',
+  name: 'raix:push',
+  version: '2.6.0',
   summary: 'Isomorphic Push notifications for APN and GCM',
-  git: 'https://github.com/workpop/push.git'
+  git: 'https://github.com/raix/push.git'
 });
 
 // Server-side push deps

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'workpop:push',
-  version: '2.5.3',
+  version: '2.5.4',
   summary: 'Isomorphic Push notifications for APN and GCM',
   git: 'https://github.com/workpop/push.git'
 });

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'raix:push',
-  version: '2.5.1',
+  name: 'workpop:push',
+  version: '2.5.2',
   summary: 'Isomorphic Push notifications for APN and GCM',
-  git: 'https://github.com/raix/push.git'
+  git: 'https://github.com/workpop/push.git'
 });
 
 // Server-side push deps

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'workpop:push',
-  version: '2.5.2',
+  version: '2.5.3',
   summary: 'Isomorphic Push notifications for APN and GCM',
   git: 'https://github.com/workpop/push.git'
 });

--- a/plugin/push.configuration.js
+++ b/plugin/push.configuration.js
@@ -107,7 +107,7 @@ var archConfig = {
     if (result) cloneCommon(config, result);
 
     return result;
-  },
+  }
 };
 
 var configStringify = function(config) {


### PR DESCRIPTION
I'm proposing a breaking change to simplify the push-update method and thus bumping the version to 2.6.0.

The main change is to `raix:push-update` method.

Currently the user must supply the `id` parameter in the call. They are forced to generate this before sending the request.

With my change, this process becomes simpler. The client can send only the appName, token, and userId to create a new application record on the server.  If the `id` field is included in the call to `raix:push-update` then it will attempt to find that specific record and update it if its found, which makes sense for the name `push-update`, otherwise will return a 404 if that `id` does not yet exist. I think this is much more intuitive behavior.

All other logic of locating by token/appName is left intact. The method still returns the recordId to the client for use in any future calls to `raix:push-update` or `raix:push-setuser` or `raix:push-metadata` as the `id` param.

Also includes some added documentation and cleanup.