### PR TITLE
added category support for APNS

### DIFF
--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -135,7 +135,11 @@ Push.Configure = function(options) {
             note.expiry = Math.floor(Date.now() / 1000) + 3600; // Expires 1 hour from now.
             if (typeof notification.badge !== 'undefined') note.badge = notification.badge;
             if (typeof notification.sound !== 'undefined') note.sound = notification.sound;
-
+            
+            // adds category support for iOS8 custom actions as described here:
+            // https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/IPhoneOSClientImp.html#//apple_ref/doc/uid/TP40008194-CH103-SW36            
+            if (typeof notification.category !== 'undefined') note.category = notification.category;
+            
             note.alert = notification.text;
             // Allow the user to set payload data
             note.payload = (notification.payload) ? { ejson: EJSON.stringify(notification.payload) } : {};


### PR DESCRIPTION
I'd like this method to support some more of the features added in iOS8.  We are developing a Meteor integration with the Apple Watch, which has the need to use the "category" field of the APNS payload to support custom notification actions.

This pull request adds category support for iOS8 custom actions as described here:
https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/IPhoneOSClientImp.html#//apple_ref/doc/uid/TP40008194-CH103-SW36            
            