### PR TITLE
Enable multiple notifications on Android

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -185,6 +185,11 @@ Push.send({
   tokens: [{},{}] 
 });
 ```
+#### Display multiple notifications on Android
+ * `notId` : a unique identifier for a GCM message
+
+'notId' supplies a unique id to Cordova Push plugin for 'tag' field in GCM (Android) allowing a per message id, this can be used to replace unread message on both server and client. It differs from collapseKey which only collapses undelivered messages server side. Defaults to a value of zero, must be 32 bit Integer
+If `notId` is not set then the Push plugin defaults to a value of 0 causing each message to overwrite the previous and only ever display a single notification.
 
 ### Client Security
 This package allows you to send notifications from the server and client. To restrict the client or allowing the client to send use `allow` or `deny` rules.

--- a/lib/common/notifications.js
+++ b/lib/common/notifications.js
@@ -12,6 +12,7 @@ var _validateDocument = function(notification) {
     text: String,
     badge: Match.Optional(Number),
     sound: Match.Optional(String),
+    notId: Match.Optional(Match.Integer),
     query: Match.Optional(String),
     token: Match.Optional(_matchToken),
     tokens: Match.Optional([_matchToken]),
@@ -50,6 +51,7 @@ Push.send = function(options) {
   if (typeof options.payload !== 'undefined') notification.payload = options.payload;
   if (typeof options.badge !== 'undefined') notification.badge = options.badge;
   if (typeof options.sound !== 'undefined') notification.sound = options.sound;
+  if (typeof options.notId !== 'undefined') notification.notId = options.notId;
 
   // Set one token selector, this can be token, array of tokens or query
   if (options.query) {

--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -210,7 +210,7 @@ Push.Configure = function(options) {
             if (typeof notification.badge !== 'undefined') data.msgcnt = notification.badge;
             if (typeof notification.sound !== 'undefined') data.soundname = notification.sound;
             if (typeof notification.notId !== 'undefined') data.notId = notification.notId;
-            
+
             //var message = new gcm.Message();
             var message = new gcm.Message({
                 collapseKey: notification.from,

--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -209,7 +209,8 @@ Push.Configure = function(options) {
             // Set extra details
             if (typeof notification.badge !== 'undefined') data.msgcnt = notification.badge;
             if (typeof notification.sound !== 'undefined') data.soundname = notification.sound;
-
+            if (typeof notification.notId !== 'undefined') data.notId = notification.notId;
+            
             //var message = new gcm.Message();
             var message = new gcm.Message({
                 collapseKey: notification.from,


### PR DESCRIPTION
@raix Currently on Android, the Push package overwrites each additional message sent to mobile device due to the Cordova Push plugin setting the `tag` value of the GCM message to 0 by default. This pull allows the setting of an optional `notId` parameter to be passed to the notification object and will cause the client device to display multiple messages in the notifications bar. Each of these can be individually overwritten on client or server by reusing the same notId. 

The `notId` can also be set to a random value to ensure that all message have their own notification in the notification bar. The exception to this is when the messages are undelivered and stack up server side in which case if a collapseKey is defined, only the latest message from each collapse key will be used (up to a limit of 4 collapseKeys).

The `notId` can only be a 32 bit Integer due to the limitations placed on it by the Cordova Push plugin which will parse the value as such. Notification validation has been updated to check for a valid Integer value as part of this pull.