### PR TITLE
Fix for APN feedback API and handling transmission errors

### DIFF
--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -124,7 +124,20 @@ Push.Configure = function(options) {
         var apn = Npm.require('apn');
         var apnConnection = new apn.Connection( options.apn );
 
+        // Listen to transmission errors - should handle the same way as feedback.
+        apnConnection.on('transmissionError', Meteor.bindEnvironment(function (errCode, notification, recipient) {
+          if (Push.debug) {
+            console.log('Got error code %d for token %s', errCode, notification.token);
+          }
+          if ([2, 5, 8].indexOf(errCode) >= 0) {
 
+
+            // Invalid token errors...
+            _removeToken({
+              apn: notification.token
+            });
+          }
+        }));
         // XXX: should we do a test of the connection? It would be nice to know
         // That the server/certificates/network are correct configured
 
@@ -171,6 +184,10 @@ Push.Configure = function(options) {
             note.payload.messageFrom = notification.from;
             note.priority = priority;
 
+
+            // Store the token on the note so we can reference it if there was an error
+            note.token = userToken;
+
             // console.log('I:Send message to: ' + userToken + ' count=' + count);
 
             apnConnection.pushNotification(note, myDevice);
@@ -178,25 +195,34 @@ Push.Configure = function(options) {
         };
 
 
-        var initFeedback = function() {
+        var initFeedback = function () {
             var apn = Npm.require('apn');
             // console.log('Init feedback');
             var feedbackOptions = {
-                "batchFeedback": true,
-                "interval": 1000,
-                'address': 'feedback.push.apple.com'
+                'batchFeedback': true,
+
+                // Time in SECONDS
+                'interval': 5,
+                production: !options.apn.development,
+                cert: options.certData,
+                key: options.keyData,
+                passphrase: options.passphrase
             };
 
             var feedback = new apn.Feedback(feedbackOptions);
-            feedback.on("feedback", function(devices) {
-                devices.forEach(function(item) {
+            feedback.on('feedback', function (devices) {
+                devices.forEach(function (item) {
                     // Do something with item.device and item.time;
                     // console.log('A:PUSH FEEDBACK ' + item.device + ' - ' + item.time);
                     // The app is most likely removed from the device, we should
                     // remove the token
-                    _removeToken({ apn: item.device});
+                    _removeToken({
+                        apn: item.device
+                    });
                 });
             });
+
+            feedback.start();
         };
 
         // Init feedback from apn server
@@ -418,7 +444,7 @@ Push.Configure = function(options) {
     };
 
     self.serverSend = function(options) {
-      options = options || { badge: 0 };
+      options = options || { badge: 0 };
       var query;
 
       // Check basic options
@@ -543,7 +569,7 @@ Push.Configure = function(options) {
                 { sending: { $ne: true } },
                 // And not queued for future
                 { $or: [ { delayUntil: { $exists: false } }, { delayUntil:  { $lte: new Date() } } ] }
-  		      ]}, {
+            ]}, {
               // Sort by created date
               sort: { createdAt: 1 },
               limit: batchSize


### PR DESCRIPTION
The setup of the `apn.Feedback` functionality was incorrect.

Also, APN sends an error code right away for tokens that aren't valid, and the `apn` package emits a `transmissionError` when that happens. I added a listener to handle errors and run `_removeToken`. The response doesn't have the actual token, so in order to ID the token to remove I had to add the token as an arbitrary property on the notification. I confirmed this does not affect the actual delivery.