### PR TITLE
Fixed bug which prevented common settings in config.push.json from being parsed

### DIFF
--- a/plugin/push.configuration.js
+++ b/plugin/push.configuration.js
@@ -47,7 +47,7 @@ var checkConfig = function(config) { // jshint ignore:line
 
 var clone = function(name, config, result) {
   if (typeof config[name] !== 'undefined') {
-    result.name = config.name;
+    result[name] = config[name];
   }
 };
 


### PR DESCRIPTION
Fixed clone function which previously prevented common settings (e.g. 'production') from being created