### PR TITLE
enable keepNotifications option to be set in config file

### DIFF
--- a/plugin/push.configuration.js
+++ b/plugin/push.configuration.js
@@ -31,7 +31,9 @@ var checkConfig = function(config) { // jshint ignore:line
     // Controls the sending interval
     sendInterval: Match.Optional(Number),
     // Controls the sending batch size per interval
-    sendBatchSize: Match.Optional(Number)
+    sendBatchSize: Match.Optional(Number),
+    // Allow optional keeping notifications in collection
+    keepNotifications: Match.Optional(Boolean)
   });
 
   // Make sure at least one service is configured?
@@ -59,6 +61,7 @@ var cloneCommon = function(config, result) {
   clone('vibrate', config, result);
   clone('sendInterval', config, result);
   clone('sendBatchSize', config, result);
+  clone('keepNotifications', config, result);
 };
 
 var archConfig = {


### PR DESCRIPTION
The server api checks options.keepNotifications before deleting a sent notification from the collection... 
https://github.com/raix/push/blob/c1602dddd9c159d4c8aeb84e53d4118b805f354c/lib/server/push.api.js#L610

I tried to enable it and discovered it to be impossible... so I made these changes.