### PR TITLE
Adding contentAvailable option to config

### DIFF
--- a/lib/common/notifications.js
+++ b/lib/common/notifications.js
@@ -13,6 +13,7 @@ var _validateDocument = function(notification) {
     badge: Match.Optional(Number),
     sound: Match.Optional(String),
     notId: Match.Optional(Match.Integer),
+    contentAvailable: Match.Optional(Match.Integer),
     apn: Match.Optional({
       from: Match.Optional(String),
       title: Match.Optional(String),
@@ -84,6 +85,10 @@ Push.send = function(options) {
   } else if (options.tokens) {
     // Set tokens
     notification.tokens = options.tokens;
+  }
+  //console.log(options);
+  if (typeof options.contentAvailable !== 'undefined') {
+    notification.contentAvailable = options.contentAvailable;
   }
 
   // Validate the notification

--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -169,8 +169,16 @@ Push.Configure = function(options) {
             if (typeof notification.sound !== 'undefined') {
               note.sound = notification.sound;
             }
+            //console.log(notification.contentAvailable);
+            //console.log("lala2");
+            //console.log(notification);
+            if (typeof notification.contentAvailable !== 'undefined') {
+              //console.log("lala");
+              note.setContentAvailable(notification.contentAvailable);
+              //console.log(note);
+            }
 
-            // adds category support for iOS8 custom actions as described here:
+          // adds category support for iOS8 custom actions as described here:
             // https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/
             // RemoteNotificationsPG/Chapters/IPhoneOSClientImp.html#//apple_ref/doc/uid/TP40008194-CH103-SW36
             if (typeof notification.category !== 'undefined') {


### PR DESCRIPTION
Solving issue #38 https://github.com/raix/push/issues/38 

Adding contentAvailable option to Push.send({}) for supporting background callback/fetch on iOS.

Usage:

Push.send({
         contentAvailable: 1
});