### PR TITLE
Update plugin, add actionable notifications

### DIFF
--- a/lib/common/notifications.js
+++ b/lib/common/notifications.js
@@ -12,6 +12,7 @@ var _validateDocument = function(notification) {
     text: String,
     badge: Match.Optional(Match.Integer),
     sound: Match.Optional(String),
+    category: Match.Optional(String),
     notId: Match.Optional(Match.Integer),
     contentAvailable: Match.Optional(Match.Integer),
     apn: Match.Optional({
@@ -89,6 +90,10 @@ Push.send = function(options) {
   //console.log(options);
   if (typeof options.contentAvailable !== 'undefined') {
     notification.contentAvailable = options.contentAvailable;
+  }
+
+  if (typeof options.category !== 'undefined') {
+    notification.category = options.category;
   }
 
   // Validate the notification

--- a/package.js
+++ b/package.js
@@ -12,7 +12,7 @@ Npm.depends({
 });
 
 Cordova.depends({
-  'phonegap-plugin-push': '1.3.0'
+  'phonegap-plugin-push': '1.5.3'
 });
 
 Package.registerBuildPlugin({

--- a/plugin/push.configuration.js
+++ b/plugin/push.configuration.js
@@ -33,7 +33,8 @@ var checkConfig = function(config) { // jshint ignore:line
     // Controls the sending batch size per interval
     sendBatchSize: Match.Optional(Number),
     // Allow optional keeping notifications in collection
-    keepNotifications: Match.Optional(Boolean)
+    keepNotifications: Match.Optional(Boolean),
+    categories: Match.Optional(Object)
   });
 
   // Make sure at least one service is configured?
@@ -62,6 +63,7 @@ var cloneCommon = function(config, result) {
   clone('sendInterval', config, result);
   clone('sendBatchSize', config, result);
   clone('keepNotifications', config, result);
+  clone('categories', config, result);
 };
 
 var archConfig = {
@@ -115,6 +117,9 @@ var archConfig = {
         badge: Boolean(config.badge),
         sound: Boolean(config.sound)
       };
+      if(config.categories){
+        result.ios.categories = config.categories
+      }
     }
 
     if (result) {


### PR DESCRIPTION
I was able to get the actionable notifications working as described [here](https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#action-buttons-1). I have only tested with iOS version 9.2