### PR TITLE
Fix for issue #181.

### DIFF
--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -568,88 +568,96 @@ Push.Configure = function(options) {
           if (isSendingNotification) {
               return;
           }
-          // Set send fence
-          isSendingNotification = true;
+          try {
+              // Set send fence
+              isSendingNotification = true;
 
-          // var countSent = 0;
-          var batchSize = options.sendBatchSize || 1;
+              // var countSent = 0;
+              var batchSize = options.sendBatchSize || 1;
+  
+              // Find notifications that are not being or already sent
+              var pendingNotifications = Push.notifications.find({ $and: [
+                    // Message is not sent
+                    { sent : { $ne: true } },
+                    // And not being sent by other instances
+                    { sending: { $ne: true } },
+                    // And not queued for future
+                    { $or: [ { delayUntil: { $exists: false } }, { delayUntil:  { $lte: new Date() } } ] }
+                ]}, {
+                  // Sort by created date
+                  sort: { createdAt: 1 },
+                  limit: batchSize
+                });
 
-          // Find notifications that are not being or already sent
-          var pendingNotifications = Push.notifications.find({ $and: [
-                // Message is not sent
-                { sent : { $ne: true } },
-                // And not being sent by other instances
-                { sending: { $ne: true } },
-                // And not queued for future
-                { $or: [ { delayUntil: { $exists: false } }, { delayUntil:  { $lte: new Date() } } ] }
-            ]}, {
-              // Sort by created date
-              sort: { createdAt: 1 },
-              limit: batchSize
-            });
+              pendingNotifications.forEach(function(notification) {
+                  // Reserve notification
+                  var reserved = Push.notifications.update({ $and: [
+                    // Try to reserve the current notification
+                    { _id: notification._id },
+                    // Make sure no other instances have reserved it
+                    { sending: { $ne: true } }
+                  ]}, {
+                    $set: {
+                      // Try to reserve
+                      sending: true
+                    }
+                  });
 
-          pendingNotifications.forEach(function(notification) {
-              // Reserve notification
-              var reserved = Push.notifications.update({ $and: [
-                // Try to reserve the current notification
-                { _id: notification._id },
-                // Make sure no other instances have reserved it
-                { sending: { $ne: true } }
-              ]}, {
-                $set: {
-                  // Try to reserve
-                  sending: true
-                }
-              });
+                  // Make sure we only handle notifications reserved by this
+                  // instance
+                  if (reserved) {
 
-              // Make sure we only handle notifications reserved by this
-              // instance
-              if (reserved) {
+                    // Check if query is set and is type String
+                    if (notification.query && notification.query === ''+notification.query) {
+                      try {
+                        // The query is in string json format - we need to parse it
+                        notification.query = JSON.parse(notification.query);
+                      } catch(err) {
+                        // Did the user tamper with this??
+                        throw new Error('Push: Error while parsing query string, Error: ' + err.message);
+                      }
+                    }
 
-                // Check if query is set and is type String
-                if (notification.query && notification.query === ''+notification.query) {
-                  try {
-                    // The query is in string json format - we need to parse it
-                    notification.query = JSON.parse(notification.query);
-                  } catch(err) {
-                    // Did the user tamper with this??
-                    throw new Error('Push: Error while parsing query string, Error: ' + err.message);
-                  }
-                }
+                    // Send the notification
+                    var result = Push.serverSend(notification);
 
-                // Send the notification
-                var result = Push.serverSend(notification);
+                    if (!options.keepNotifications) {
+                        // Pr. Default we will remove notifications
+                        Push.notifications.remove({ _id: notification._id });
+                    } else {
 
-                if (!options.keepNotifications) {
-                    // Pr. Default we will remove notifications
-                    Push.notifications.remove({ _id: notification._id });
-                } else {
+                        // Update the notification
+                        Push.notifications.update({ _id: notification._id }, {
+                            $set: {
+                              // Mark as sent
+                              sent: true,
+                              // Set the sent date
+                              sentAt: new Date(),
+                              // Count
+                              count: result,
+                              // Not being sent anymore
+                              sending: false
+                            }
+                        });
 
-                    // Update the notification
-                    Push.notifications.update({ _id: notification._id }, {
-                        $set: {
-                          // Mark as sent
-                          sent: true,
-                          // Set the sent date
-                          sentAt: new Date(),
-                          // Count
-                          count: result,
-                          // Not being sent anymore
-                          sending: false
-                        }
-                    });
+                    }
 
-                }
+                    // Emit the send
+                    self.emit('send', { notification: notification._id, result: result });
 
-                // Emit the send
-                self.emit('send', { notification: notification._id, result: result });
+                  } // Else could not reserve
 
-              } // Else could not reserve
-
-          }); // EO forEach
-
-          // Remove the send fence
-          isSendingNotification = false;
+              }); // EO forEach
+            }
+            catch (e){
+              //Prevent bubbling or all notification processing stops
+              console.log(e);
+            }
+            finally {
+              // Remove the send fence
+              isSendingNotification = false;
+            }
+         
       }, options.sendInterval || 15000); // Default every 15th sec
 
     } else {


### PR DESCRIPTION
Added a try / catch / finally block to push.api.js so that in the Meteor.setInterval function if an error occurs, the isSendingNotification fence will reset if an error is thrown.  This prevents the Meteor process from getting into a state where isSendingNotification is always true and notifications stop until Meteor is reset.