### PR TITLE
Prefix for notifications collection

### DIFF
--- a/lib/common/notifications.js
+++ b/lib/common/notifications.js
@@ -1,9 +1,5 @@
 // Notifications collection
-Push.notifications = new Mongo.Collection('_raix_push_notifications');
-
-if (Meteor.isServer) {
-  Push.notifications._ensureIndex({createdAt: 1});
-}
+Push.notifications;
 
 // This is a general function to validate that the data added to notifications
 // is in the correct format. If not this function will throw errors

--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -36,6 +36,15 @@ Push.Configure = function(options) {
     // Add debug info
     if (Push.debug) console.log('Push.Configure', options);
 
+    // config collections for project
+    var prefix = options.dbCollectionPrefix || '';
+    var notificationsCollection =  prefix + '_raix_push_notifications';
+    Push.notifications = new Mongo.Collection(notificationsCollection);
+
+    if (Meteor.isServer) {
+      Push.notifications._ensureIndex({createdAt: 1});
+    }
+
     // This function is called when a token is replaced on a device - normally
     // this should not happen, but if it does we should take action on it
     _replaceToken = function(currentToken, newToken) {
@@ -509,7 +518,7 @@ Push.Configure = function(options) {
 
               if (!options.keepNotifications) {
                   // Pr. Default we will remove notifications
-                  Push.notifications.remove({ _id: notification._id });
+                  //Push.notifications.remove({ _id: notification._id });
               } else {
 
                   // Update the notification

--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -518,7 +518,7 @@ Push.Configure = function(options) {
 
               if (!options.keepNotifications) {
                   // Pr. Default we will remove notifications
-                  //Push.notifications.remove({ _id: notification._id });
+                  Push.notifications.remove({ _id: notification._id });
               } else {
 
                   // Update the notification

--- a/plugin/push.configuration.js
+++ b/plugin/push.configuration.js
@@ -28,7 +28,9 @@ var checkConfig = function(config) {
     // Controls the sending interval
     sendInterval: Match.Optional(Number),
     // Controls the sending batch size per interval
-    sendBatchSize: Match.Optional(Number)
+    sendBatchSize: Match.Optional(Number),
+    // prefix for notifications collection
+    dbCollectionPrefix: Match.Optional(String)
   });
 
   // Make sure at least one service is configured?
@@ -53,6 +55,7 @@ var cloneCommon = function(config, result) {
   clone('vibrate', config, result);
   clone('sendInterval', config, result);
   clone('sendBatchSize', config, result);
+  clone('dbCollectionPrefix', config, result);
 };
 
 var archConfig = {


### PR DESCRIPTION
We have two projects using the package and sharing the database, as the package uses a setInterval to check the notifications periodically we want to avoid any chance of error using a different collection for each project.