### PR TITLE
Prefix for notifications collection

### DIFF
--- a/lib/common/notifications.js
+++ b/lib/common/notifications.js
@@ -2,7 +2,7 @@
 _matchToken = Match.OneOf({ apn: String }, { gcm: String });
 
 // Notifications collection
-Push.notifications = new Mongo.Collection('_raix_push_notifications');
+Push.notifications;
 
 // This is a general function to validate that the data added to notifications
 // is in the correct format. If not this function will throw errors

--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -41,6 +41,11 @@ Push.Configure = function(options) {
       console.log('Push.Configure', options);
     }
 
+    // config collections for project
+    var prefix = options.dbCollectionPrefix || '';
+    var notificationsCollection =  prefix + '_raix_push_notifications';
+    Push.notifications = new Mongo.Collection(notificationsCollection);
+
     // This function is called when a token is replaced on a device - normally
     // this should not happen, but if it does we should take action on it
     _replaceToken = function(currentToken, newToken) {

--- a/plugin/push.configuration.js
+++ b/plugin/push.configuration.js
@@ -33,7 +33,8 @@ var checkConfig = function(config) { // jshint ignore:line
     // Controls the sending batch size per interval
     sendBatchSize: Match.Optional(Number),
     // Allow optional keeping notifications in collection
-    keepNotifications: Match.Optional(Boolean)
+    keepNotifications: Match.Optional(Boolean),
+    dbCollectionPrefix: Match.Optional(String)
   });
 
   // Make sure at least one service is configured?
@@ -62,6 +63,7 @@ var cloneCommon = function(config, result) {
   clone('sendInterval', config, result);
   clone('sendBatchSize', config, result);
   clone('keepNotifications', config, result);
+  clone('dbCollectionPrefix', config, result);
 };
 
 var archConfig = {


### PR DESCRIPTION
We have two projects using the package and sharing the database, as the package uses a setInterval to check the notifications periodically we want to avoid any chance of error using a different collection for each project.