### PR TITLE
Add support for additional GCM fields: picture, style and summaryText 

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -238,10 +238,69 @@ Push.send({
     image: 'https://c1.staticflickr.com/9/8079/8391224056_96da82499d_n.jpg'
   }
 });
-
-Produces the following notification.
 ```
+
+Produces the following result:
 ![2015-07-24 02 17 55](https://cloud.githubusercontent.com/assets/353180/8866900/2df0ab06-3190-11e5-9a81-fdb85bb0f5a4.png)
+
+### Android styles
+
+#### Inbox style
+
+First notification:
+
+```js
+Push.send({
+  from: 'Test',
+  title: 'My Title',
+  text: 'My first message',
+  gcm: {
+    style: 'inbox',
+    summaryText: 'There are %n% notifications'
+  }
+});
+```
+
+Produces the following result:
+![first message](https://cloud.githubusercontent.com/assets/353180/9468840/c9c5d43a-4b11-11e5-814f-8dc995f47830.png)
+
+Second notification:
+
+```js
+Push.send({
+  from: 'Test',
+  title: 'My Title',
+  text: 'My second message',
+  gcm: {
+    style: 'inbox',
+    summaryText: 'There are %n% notifications'
+  }
+});
+```
+
+Produces the following result:
+![second message](https://cloud.githubusercontent.com/assets/353180/9468727/2d658bee-4b11-11e5-90fa-248d54c8f3f6.png)
+
+#### Picture Messages
+
+To include a large picture in the notification:
+
+```js
+Push.send({
+  from: 'Test',
+  title: 'Big Picture',
+  text: 'This is my big picture message',
+  gcm: {
+    style: 'picture',
+    picture: 'http://36.media.tumblr.com/c066cc2238103856c9ac506faa6f3bc2/tumblr_nmstmqtuo81tssmyno1_1280.jpg',
+    summaryText: 'The internet is built on cat pictures'
+  }
+});
+```
+
+Produces the following result:
+![picture message](https://cloud.githubusercontent.com/assets/353180/9472260/3655fa7a-4b22-11e5-8d87-20528112de16.png)
+
 ### Client Security
 This package allows you to send notifications from the server and client. To restrict the client or allowing the client to send use `allow` or `deny` rules.
 

--- a/lib/common/notifications.js
+++ b/lib/common/notifications.js
@@ -30,6 +30,9 @@ var _validateDocument = function(notification) {
       title: Match.Optional(String),
       text: Match.Optional(String),
       image: Match.Optional(String),
+      style: Match.Optional(String),
+      summaryText: Match.Optional(String),
+      picture: Match.Optional(String),
       badge: Match.Optional(Match.Integer),
       sound: Match.Optional(String),
       notId: Match.Optional(Match.Integer)
@@ -76,7 +79,7 @@ Push.send = function(options) {
   }
 
   if (Match.test(options.gcm, Object)) {
-    notification.gcm = _.pick(options.gcm, 'image', 'from', 'title', 'text', 'badge', 'sound', 'notId');
+    notification.gcm = _.pick(options.gcm, 'image', 'style', 'summaryText', 'picture', 'from', 'title', 'text', 'badge', 'sound', 'notId');
   }
 
   // Set one token selector, this can be token, array of tokens or query

--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -291,6 +291,15 @@ Push.Configure = function(options) {
             if (typeof notification.notId !== 'undefined') {
               data.notId = notification.notId;
             }
+            if(typeof notification.style !== 'undefined') {
+              data.style = notification.style;
+            }
+            if(typeof notification.summaryText !== 'undefined') {
+              data.summaryText = notification.summaryText;
+            }
+            if(typeof notification.picture !== 'undefined') {
+              data.picture = notification.picture;
+            }
 
             //var message = new gcm.Message();
             var message = new gcm.Message({


### PR DESCRIPTION
This should close #196 

With support to this fields you'll be able to do notifications like this:

![first message](https://cloud.githubusercontent.com/assets/353180/9468840/c9c5d43a-4b11-11e5-814f-8dc995f47830.png)

![second message](https://cloud.githubusercontent.com/assets/353180/9468727/2d658bee-4b11-11e5-90fa-248d54c8f3f6.png)

![picture message](https://cloud.githubusercontent.com/assets/353180/9472260/3655fa7a-4b22-11e5-8d87-20528112de16.png)
