### PR TITLE
Update node-gcm, phonegap-plugin-push, cordova-plugin-device.

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,12 +8,12 @@ Package.describe({
 // Server-side push deps
 Npm.depends({
   'apn' : '1.6.2', // '1.7.4', // working: 1.6.2
-  'node-gcm' : '0.9.6', // '0.12.0' // working: 0.9.6
+  'node-gcm' : '0.14.4', // previously: 0.9.6
 });
 
 Cordova.depends({
-  'phonegap-plugin-push': '1.6.4', // 1.3.0
-  'cordova-plugin-device': '1.1.1',
+  'phonegap-plugin-push': '1.8.2', // previously 1.6.4
+  'cordova-plugin-device': '1.1.3', // previously 1.1.1
 });
 
 Package.registerBuildPlugin({


### PR DESCRIPTION
I didn't update node apn package as the latest one seemed to require further code changes, and the current one seems fine. Tested on iOS10 and Android 6 (marshmallow).