### PR TITLE
Current 3.1.0-pre.1 uses phonegap-plugin-push v. 1.8.2 updated to 1.8.4.

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,7 +12,7 @@ Npm.depends({
 });
 
 Cordova.depends({
-  'phonegap-plugin-push': '1.8.2', // previously 1.6.4
+  'phonegap-plugin-push': '1.8.4', // previously 1.6.4
   'cordova-plugin-device': '1.1.3', // previously 1.1.1
 });
 


### PR DESCRIPTION
1.8.2 throws the following error :
Fatal Exception: java.lang.NoSuchMethodError: No static method getNoBackupFilesDir(Landroid/content/Context;)Ljava/io/File; in class Lcom/google/android/gms/common/util/zzx; or its super classes (declaration of 'com.google.android.gms.common.util.zzx' appears in /data/app/xyz/base.apk)
       at com.google.android.gms.iid.zzd.zzeC(Unknown Source)
       at com.google.android.gms.iid.zzd.<init>(Unknown Source)
       at com.google.android.gms.iid.zzd.<init>(Unknown Source)
       at com.google.android.gms.iid.InstanceID.zza(Unknown Source)
       at com.google.android.gms.iid.InstanceID.getInstance(Unknown Source)
       at com.adobe.phonegap.push.PushPlugin$1.run(PushPlugin.java:75)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
       at java.lang.Thread.run(Thread.java:818)

More info here: https://github.com/phonegap/phonegap-plugin-push/issues/1319#issuecomment-257462713