### PR TITLE
fix: APN category field

### DIFF
--- a/lib/common/notifications.js
+++ b/lib/common/notifications.js
@@ -25,7 +25,8 @@ var _validateDocument = function(notification) {
       text: Match.Optional(String),
       badge: Match.Optional(Match.Integer),
       sound: Match.Optional(String),
-      notId: Match.Optional(Match.Integer)
+      notId: Match.Optional(Match.Integer),
+      category: Match.Optional(String)
     }),
     gcm: Match.Optional({
       from: Match.Optional(String),
@@ -77,7 +78,7 @@ Push.send = function(options) {
    _.extend(notification, _.pick(options, 'payload', 'badge', 'sound', 'notId', 'delayUntil'));
 
   if (Match.test(options.apn, Object)) {
-    notification.apn = _.pick(options.apn, 'from', 'title', 'text', 'badge', 'sound', 'notId');
+    notification.apn = _.pick(options.apn, 'from', 'title', 'text', 'badge', 'sound', 'notId', 'category');
   }
 
   if (Match.test(options.gcm, Object)) {


### PR DESCRIPTION
`category` field support was added by #68 but it did not add the bypass on validations.