### PR TITLE
feat: add support to title on iOS

### DIFF
--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -211,7 +211,14 @@ Push.Configure = function(options) {
               note.category = notification.category;
             }
 
-            note.alert = notification.text;
+            note.alert = {
+              body: notification.text
+            };
+
+            if (typeof notification.title !== 'undefined') {
+              note.alert.title = notification.title;
+            }
+
             // Allow the user to set payload data
             note.payload = (notification.payload) ? { ejson: EJSON.stringify(notification.payload) } : {};
 


### PR DESCRIPTION
According to [Apple's docs](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW2) the prefered type for `alert` is a dictionary, tha's why I changed it to have a `body` field.

And this also allowed me to add a `title` for the notification, which has support [since iOS 8.2](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW4).